### PR TITLE
Create peg-example-peg-in-peg-comments.rkt

### DIFF
--- a/tests/peg-example-peg-in-peg-comments.rkt
+++ b/tests/peg-example-peg-in-peg-comments.rkt
@@ -1,0 +1,14 @@
+#lang peg
+
+//we can use comments in the start of rules
+
+//we use '<' to mean that the matching string of input is discarted on parser
+_ < (' ' / [\t] / [\n])* ;
+
+digit <-- [0-9] ;
+number <-- digit+ ; // we can comment on the end of a rule. We can use this to explain that a number is just
+                    // a bunch of digits concatenated(minimun of 1 digit)
+                    
+ident <-- [a-zA-Z] [a-zA-Z0-9_-]* ; // yeah, charclass can be used to indicated ranges of char.
+
+//another use, final comments

--- a/tests/peg-example-peg-in-peg-comments.rkt
+++ b/tests/peg-example-peg-in-peg-comments.rkt
@@ -5,7 +5,7 @@
 //we use '<' to mean that the matching string of input is discarted on parser
 _ < (' ' / [\t] / [\n])* ;
 
-digit <-- [0-9] ;
+digit <- [0-9] ;
 number <-- digit+ ; // we can comment on the end of a rule. We can use this to explain that a number is just
                     // a bunch of digits concatenated(minimun of 1 digit)
                     

--- a/tests/peg-test-peg-in-peg-comments.rkt
+++ b/tests/peg-test-peg-in-peg-comments.rkt
@@ -1,0 +1,30 @@
+#lang racket
+
+(require peg/peg)
+(require rackunit)
+
+(require "peg-example-peg-in-peg-comments.rkt")
+
+(check-equal? (peg number "123")
+    '(number . "123")) ; 123 in decimal
+    
+(check-equal? (peg number "1024")
+    '(number . "1024")) ; 1024 in decimal
+    
+(check-equal? (peg number "0123")
+    '(number . "0123"))  ; 0123 is a octal, 83 decimal. In the way that I put, don't matter.
+    
+(check-not-equal? (peg number "0x1024")
+    '(number . "1024"))
+    
+(check-equal? (peg number "0x1024")
+    '(number . "0"))
+      ; what the hell? Simple : the parser match 0, but x is not a digit, so stop.
+      ; this is important : the parser will try to parse so long as he get, but don't
+      ; will find our desires.
+     
+#|
+  the comments in the parser don't show up in the parsed structure.
+  they are just ignored by the peg
+
+|#


### PR DESCRIPTION
One example of comments used in a file.

Maybe is a little disconnected, but my purpose was show all uses of comments

In the next I will put aritmetic expressions, after bool expressions, from my compiler's class work. This will be real examples, with comments not about comments, but showing real uses in a little complex work

Ok?