### PR TITLE
Create peg-example-expr-semantic.rkt

### DIFF
--- a/tests/peg-example-expr-semantic.rkt
+++ b/tests/peg-example-expr-semantic.rkt
@@ -1,0 +1,13 @@
+#lang peg
+
+expr <- sum ;
+
+sum <-- ((v1:product) ('+' / '-') v2:sum) / v3:product --> (if v3 v3 (list 'add v1 v2));
+
+product <-- ((v1:value) ('*' / '/') v2:product) / v3:value --> (if v3 v3 (list 'mult v1 v2));
+
+value <-- number / '(' expr ')' ;
+
+number <- v1:[0-9]+  --> (string->number v1);  //in this way, : binds so that only need parenteses if the pattern is a or
+//With semantic actions, the separation between define-peg and define-peg/tag becomes strange. The number
+//above, I use what?


### PR DESCRIPTION
With this example with reference, the semantic action can be made.

In fact, we don't need of some kind of require? If I want to put v1 and v2 in a struct? Is not good to allow definitions of struct's or things like this but a idiomatic require is necessary, right?

something like :

```
semantic "sec/semantic.rkt" ;

a <-- 'v';

...

num <- value:[0-9]+ --> (constant (string->number value)) ;
```

