### PR TITLE
update newick test, add note about empty string, add semantic action on doc, but there's error

### DIFF
--- a/scribblings/peg.scrbl
+++ b/scribblings/peg.scrbl
@@ -94,11 +94,11 @@ Using the peg lang, the example above is equal to
 @codeblock{
 #lang peg
 
-(define sentence "the quick brown fox jumps over the lazy dog") //yes, we can use
+(define sentence "the quick brown fox jumps over the lazy dog"); //yes, we can use
 //one-line comments and any sequence of s-exps BEFORE the grammar definition
 
-non-space <- (! #\space) . ; //the dot is "any-char" in peg
-word <- c:(non-space+ ~(#\space ?)) -> c ; //the ~ is drop
+non-space <- (! ' ') . ; //the dot is "any-char" in peg
+word <- c:(non-space+ ~(' ' ?)) -> c ; //the ~ is drop
 //we can use ident:peg to act as (name ident peg).
 //and rule <- exp -> action is equal to (define-peg rule exp action)
 //with this in a file, we can use the repl of drracket to do exactly the

--- a/scribblings/peg.scrbl
+++ b/scribblings/peg.scrbl
@@ -178,6 +178,8 @@ This package also provides a @racket{#lang peg} alternative, to allow you to mak
 
 The best way to understand the PEG syntax would be by reference to examples, there are many simple examples in the racket peg repo and the follow is the actual grammar used by racket-peg to implemet the peg lang:
 
+Note: When you match the empty string in peg lang, you match a empty list, not a empty string, be carefull.
+
 @verbatim{
 #lang peg
 
@@ -206,5 +208,3 @@ cc-escape-char <- '[' / ']' / '-' / '^' / '\\' / 'n' / 't';
 peg <-- _ import* rule+;
 import <-- 'import' _ name ';' _;
 }
-
-Note: When you match the empty string in peg lang, you match a empty list, not a empty string, be carefull.

--- a/scribblings/peg.scrbl
+++ b/scribblings/peg.scrbl
@@ -90,6 +90,24 @@ For a simple example, lets try splitting a sentence into words. We can describe 
 '("the" "quick" "brown" "fox" "jumps" "over" "the" "lazy" "dog")
 }
 
+Using the peg lang, the example above is equal to
+@codeblock{
+#lang peg
+
+(define *sentence* "the quick brown fox jumps over the lazy dog") //yes, we can use
+//one-line comments and any sequence of s-exps BEFORE the grammar definition
+
+non-space <- (! #\space) . ; //the dot is "any-char" in peg
+word <- c:(non-space+ ~(#\space ?)) -> c ; //the ~ is drop
+//we can use ident:peg to act as (name ident peg).
+//and rule <- exp -> action is equal to (define-peg rule exp action)
+//with this in a file, we can use the repl of drracket to do exactly the
+//uses of peg above.
+
+
+}
+
+
 @subsection{Example 2}
 
 Here is a simple calculator example that demonstrates semantic actions and recursive rules.
@@ -105,13 +123,13 @@ Here is a simple calculator example that demonstrates semantic actions and recur
   (if v2 (* v1 v2) v1))
 }
 
-this grammar(without semantic actions) is equivalenty to :
+this grammar in peg lang is equivalenty to :
 
 @codeblock{
 	#lang peg
-	number <-- res:[0-9]+ ;
-	sum <-- v1:prod ('+' v2:sum)? ;
-	prod <-- v1:number ('*' v2:prod)? ;
+	number <- res:[0-9]+ -> (string->number res);
+	sum <- v1:prod ('+' v2:sum)? -> (if v2 (+ v1 v2) v1);
+	prod <- v1:number ('*' v2:prod)? -> (if v2 (* v1 v2) v1);
 }
 
 Usage:
@@ -188,3 +206,5 @@ cc-escape-char <- '[' / ']' / '-' / '^' / '\\' / 'n' / 't';
 peg <-- _ import* rule+;
 import <-- 'import' _ name ';' _;
 }
+
+Note: When you match the empty string in peg lang, you match a empty list, not a empty string, be carefull.

--- a/scribblings/peg.scrbl
+++ b/scribblings/peg.scrbl
@@ -78,15 +78,15 @@ For a simple example, lets try splitting a sentence into words. We can describe 
 
 @codeblock{
 > (require peg)
-> (define *sentence* "the quick brown fox jumps over the lazy dog")
+> (define sentence "the quick brown fox jumps over the lazy dog")
 > (define-peg non-space
     (and (! #\space) (any-char)))
 > (define-peg/bake word
     (and (+ non-space)
          (drop (? #\space))))
-> (peg word *sentence*)
+> (peg word sentence)
 "the"
-> (peg (+ word) *sentence*)
+> (peg (+ word) sentence)
 '("the" "quick" "brown" "fox" "jumps" "over" "the" "lazy" "dog")
 }
 
@@ -94,7 +94,7 @@ Using the peg lang, the example above is equal to
 @codeblock{
 #lang peg
 
-(define *sentence* "the quick brown fox jumps over the lazy dog") //yes, we can use
+(define sentence "the quick brown fox jumps over the lazy dog") //yes, we can use
 //one-line comments and any sequence of s-exps BEFORE the grammar definition
 
 non-space <- (! #\space) . ; //the dot is "any-char" in peg

--- a/tests/peg-syntax-harness/test-newick.rkt
+++ b/tests/peg-syntax-harness/test-newick.rkt
@@ -1,5 +1,6 @@
 #lang racket
 
+(require peg)
 (require rackunit)
 
 (require "../peg-syntax/peg-example-newick.rkt")


### PR DESCRIPTION
As the commit say, theres error in the scribble because of 

```
(define sentence "the quick brown fox jumps over the lazy dog");
 //yes, we can use
//one-line comments and any sequence of s-exps BEFORE the grammar definition

non-space <- (! ' ') . ; //the dot is "any-char" in peg
word <- c:(non-space+ ~(' ' ?)) -> c ; //the ~ is drop
//we can use ident:peg to act as (name ident peg).
//and rule <- exp -> action is equal to (define-peg rule exp action)
//with this in a file, we can use the repl of drracket to do exactly the
//uses of peg above.
```

but this works in drracket with lang peg, I tried but could not eliminate the error