### PR TITLE
change make to ./make and add ground to verbose debugging support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@ This library implements a PEG parser generator.
 
 ## Getting Started
 
-* Run `make install` to install the peg library. You should be able to `(require peg)` in your own racket programs after that. Or use `#lang peg`!
+* run `chmod +x ./make` to turn ./make executable
 
-* Run `make update` to apply changes, if you're hacking on it.
+* Run `./make install` to install the peg library. You should be able to `(require peg)` in your own racket programs after that. Or use `#lang peg`!
 
-* Run `make docs` to build the documentation.
+* Run `./make update` to apply changes, if you're hacking on it.
 
-* Run `make test` to check that it is working after installation.
+* Run `./make docs` to build the documentation.
+
+* Run `./make test` to check that it is working after installation.
 
 ## Source Code Map
 

--- a/make
+++ b/make
@@ -2,7 +2,7 @@
 
 set -x
 
-if [[ $# -eq 0 ]]
+if [ $# -eq 0 ];
 then
 	echo targets are
 	echo \* install

--- a/peg.rkt
+++ b/peg.rkt
@@ -45,6 +45,8 @@
 ;;;;
 ;; pegvm registers and dynamic control
 
+
+(define pegvm-verbose (make-parameter #f))
 (define pegvm-input-text (make-parameter #f))      ;; The input string being parsed
 (define pegvm-input-position (make-parameter #f))  ;; The position inside the string
 (define pegvm-control-stack (make-parameter #f))   ;; For or control flow
@@ -281,7 +283,8 @@
 
 (define-syntax (peg stx)
   (syntax-case stx ()
-    [(_ exp str)
+    [(_ exp str) #'(peg exp str #f)]
+    [(_ exp str v)
      #'(let ((fail-cont (lambda ()
                           (let ((loc (car (unbox (pegvm-best-failure)))))
                             (display (string-replace (string-replace (copy-and-pad-substring (pegvm-input-text) (- loc 10) (+ loc 10))
@@ -301,5 +304,6 @@
                         [pegvm-control-stack (box (list (control-frame #f fail-cont)))]
                         [pegvm-stashed-stacks (box '())]
                         [pegvm-negation? (box 0)]
-                        [pegvm-best-failure (box #f)])
+                        [pegvm-best-failure (box #f)]
+			[pegvm-verbose v])
            (peg-rule:local success-cont)))]))

--- a/peg.rkt
+++ b/peg.rkt
@@ -189,7 +189,10 @@
        (peg-compile #'(? (and e1 e2 ...)) #'sk)]
       [(call rule-name)
        (with-syntax ([rule (format-id #'rule-name "peg-rule:~a" #'rule-name)])
-		    #'(rule sk))]
+		    #'(if (pegvm-verbose)
+			  (parameterize ((pegvm-verbose (+ (pegvm-verbose) 1)))
+			    (rule sk))
+			  (rule sk)))]
       [(name nm e)
        (with-syntax ([p (peg-compile #'e #'sk^)])
          #'(let ((sk^ (lambda (r)
@@ -243,6 +246,7 @@
                    [action (if (syntax-e #'has-action?) #'action #'res)])
        #'(define (name sk)
 	   (when (pegvm-verbose)
+	     (display (make-string (pegvm-verbose) #\space))
 	     (display 'name)
 	     (newline))
            (parameterize ([pegvm-current-rule 'name])
@@ -308,7 +312,7 @@
                         [pegvm-stashed-stacks (box '())]
                         [pegvm-negation? (box 0)]
                         [pegvm-best-failure (box #f)]
-			[pegvm-verbose v])
+			[pegvm-verbose (if v 0 #f)])
 	   (peg-rule:local success-cont)))]))
 
 

--- a/peg.rkt
+++ b/peg.rkt
@@ -188,9 +188,8 @@
       [(? e1 e2 ...)
        (peg-compile #'(? (and e1 e2 ...)) #'sk)]
       [(call rule-name)
-       (with-syntax ([rule (format-id #'rule-name "peg-rule:~a" #'rule-name)]
-		     [rule-debug (format-id #'rule-name "peg-rule:~a-debug" #'rule-name)])
-         #'(if (pegvm-verbose) (rule-debug sk) (rule sk)))]
+       (with-syntax ([rule (format-id #'rule-name "peg-rule:~a" #'rule-name)])
+		    #'(rule sk))]
       [(name nm e)
        (with-syntax ([p (peg-compile #'e #'sk^)])
          #'(let ((sk^ (lambda (r)
@@ -239,22 +238,17 @@
      #'(define-peg rule-name exp action #t)]
     [(_ rule-name exp action has-action?)
      (with-syntax ([name (format-id #'rule-name "peg-rule:~a" (syntax-e #'rule-name))]
-		   [name-debug (format-id #'rule-name "peg-rule:~a-debug" (syntax-e #'rule-name))]
                    [bindings (map make-binding (peg-names #'exp))]
                    [body (peg-compile #'exp #'sk^)]
                    [action (if (syntax-e #'has-action?) #'action #'res)])
-       #'(begin
-		(define (name sk)
-        	   (parameterize ([pegvm-current-rule 'name])
-	             (let* bindings
-	               (let ((sk^ (lambda (res) (sk action))))
-	                 body))))
-		(define (name-debug sk)
-		(parameterize ([pegvm-current-rule 'name-debug])
-	             (let* bindings
-	               (let ((sk^ (lambda (res) (sk action))))
-	                 body))))
-		(trace name-debug)))]))
+       #'(define (name sk)
+	   (when (pegvm-verbose)
+	     (display 'name)
+	     (newline))
+           (parameterize ([pegvm-current-rule 'name])
+	     (let* bindings
+	       (let ((sk^ (lambda (res) (sk action))))
+	         body)))))]))
 
 (define-syntax (define-peg/drop stx)
   (syntax-case stx () [(_ rule-name exp) #'(define-peg rule-name (drop exp))]))
@@ -315,6 +309,6 @@
                         [pegvm-negation? (box 0)]
                         [pegvm-best-failure (box #f)]
 			[pegvm-verbose v])
-	   (if (pegvm-verbose)
-		(peg-rule:local-debug success-cont)
-	           (peg-rule:local success-cont))))]))
+	   (peg-rule:local success-cont)))]))
+
+

--- a/peg.rkt
+++ b/peg.rkt
@@ -190,7 +190,7 @@
       [(call rule-name)
        (with-syntax ([rule (format-id #'rule-name "peg-rule:~a" #'rule-name)]
 		     [rule-debug (format-id #'rule-name "peg-rule:~a-debug" #'rule-name)])
-         #'(if pegvm-verbose (rule-debug sk) (rule sk)))]
+         #'(if (pegvm-verbose) (rule-debug sk) (rule sk)))]
       [(name nm e)
        (with-syntax ([p (peg-compile #'e #'sk^)])
          #'(let ((sk^ (lambda (r)
@@ -238,8 +238,8 @@
     [(_ rule-name exp action)
      #'(define-peg rule-name exp action #t)]
     [(_ rule-name exp action has-action?)
-     (with-syntax ([name (format-id #'rule-name "peg-rule:~a" #'rule-name)]
-		   [name-debug (format-id #'rule-name "peg-rule:~a-debug" #'rule-name)]
+     (with-syntax ([name (format-id #'rule-name "peg-rule:~a" (syntax-e #'rule-name))]
+		   [name-debug (format-id #'rule-name "peg-rule:~a-debug" (syntax-e #'rule-name))]
                    [bindings (map make-binding (peg-names #'exp))]
                    [body (peg-compile #'exp #'sk^)]
                    [action (if (syntax-e #'has-action?) #'action #'res)])
@@ -249,11 +249,12 @@
 	             (let* bindings
 	               (let ((sk^ (lambda (res) (sk action))))
 	                 body))))
-		(trace-define (name-debug sk)
+		(define (name-debug sk)
 		(parameterize ([pegvm-current-rule 'name-debug])
 	             (let* bindings
 	               (let ((sk^ (lambda (res) (sk action))))
-	                 body))))))]))
+	                 body))))
+		(trace name-debug)))]))
 
 (define-syntax (define-peg/drop stx)
   (syntax-case stx () [(_ rule-name exp) #'(define-peg rule-name (drop exp))]))
@@ -314,6 +315,6 @@
                         [pegvm-negation? (box 0)]
                         [pegvm-best-failure (box #f)]
 			[pegvm-verbose v])
-	   (if pegvm-verbose
+	   (if (pegvm-verbose)
 		(peg-rule:local-debug success-cont)
 	           (peg-rule:local success-cont))))]))

--- a/tests/test-verbose.rkt
+++ b/tests/test-verbose.rkt
@@ -12,5 +12,14 @@
 
 
 ;the result is 135, showed in the last line. ALL before is debug
-(check-equal? ">(peg-rule:local-debug #<procedure:peg-result->object>)\n>(peg-rule:sum-debug #<procedure:sk^>)\n>(peg-rule:number-debug #<procedure:sk^>)\n>(peg-rule:number-debug #<procedure:sk^>)\n<135\n" (with-output-to-string (lambda () (peg sum "12+123" #t))))
+;(check-equal? ">(peg-rule:local-debug #<procedure:peg-result->object>)\n>(peg-rule:sum-debug #<procedure:sk^>)\n>(peg-rule:number-debug #<procedure:sk^>)\n>(peg-rule:number-debug #<procedure:sk^>)\n<135\n" (with-output-to-string (lambda () (peg sum "12+123" #t))))
 
+;> (peg (and sum (and "," sum)) "12+123,55+33" #t)
+;peg-rule:local
+; peg-rule:sum
+;  peg-rule:number
+;   peg-rule:number
+;    peg-rule:sum
+;     peg-rule:number
+;      peg-rule:number
+;'(135 "," 88)

--- a/tests/test-verbose.rkt
+++ b/tests/test-verbose.rkt
@@ -1,0 +1,16 @@
+#lang racket
+
+(require rackunit)
+(require peg)
+
+(define-peg number (name v (+ (range #\0 #\9))) (string->number v))
+(define-peg sum (and (name v1 number) "+" (name v2 number)) (+ v1 v2))
+
+
+;because in non-debug mode, nothing is printed, just returned
+(check-equal? "" (with-output-to-string (lambda () (peg sum "12+123"))))
+
+
+;the result is 135, showed in the last line. ALL before is debug
+(check-equal? ">(peg-rule:local-debug #<procedure:peg-result->object>)\n>(peg-rule:sum-debug #<procedure:sk^>)\n>(peg-rule:number-debug #<procedure:sk^>)\n>(peg-rule:number-debug #<procedure:sk^>)\n<135\n" (with-output-to-string (lambda () (peg sum "12+123" #t))))
+


### PR DESCRIPTION
pegvm-verbose is a boolean that control if, when executing the code
will show the message "go inside number rule" when enter the number
rule code.

I don't know how to show this. I try using pegvm-current-rule, but
is a procedure. I see that format-id can transform from symbols to
identifiers, but how to transform to string, so we can display?