### PR TITLE
Support parsing directly from ports

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -15,7 +15,7 @@
 
 (define (peg-port->scheme in)
   (peg->scheme (car
-                  (peg-result->object (peg (and peg (! (any-char))) (port->string in))))))
+                  (peg-result->object (peg (and peg (! (any-char))) in)))))
 
 (define (literal-read in)
   (syntax->datum

--- a/scribblings/peg.scrbl
+++ b/scribblings/peg.scrbl
@@ -1,6 +1,7 @@
 #lang scribble/manual
 @require[@for-label[peg
-                    racket/base]
+                    racket/base
+                    racket/contract/base]
          scribble/bnf]
 
 @title{PEG}
@@ -66,8 +67,11 @@ tags the result with the peg rule name. Useful for parsers that create an AST.
 
 @subsection{peg}
 
-@defform[#:link-target? #f (peg rule input-text)]{
-Run a PEG parser. Attempt to parse the @racket[input-text] string using the given @racket[rule]. This is sets up the PEG VM registers into an initial state and then calls into the parser for @racket[rule].
+@defform[#:link-target? #f (peg rule input)
+  #:contracts ([input (or/c string? input-port?)])]{
+Runs a PEG parser and attempts to parse @racket[input] using the given @racket[rule]. This sets up the PEG VM registers into an initial state and then calls into the parser for @racket[rule].
+
+If @racket[input] is a port, and @racket[(port-counts-lines? input)] returns @racket[#t], then parse errors will be reported at the actual position in the file. Otherwise, reported locations are relative to the point at which parsing started.
 }
 
 @section{Examples}

--- a/tests/peg-syntax/peg-example-quests.rkt
+++ b/tests/peg-syntax/peg-example-quests.rkt
@@ -6,7 +6,7 @@
 (provide (all-from-out "peg-example-shell.rkt"));
 
 (define (parser-quest port)
-  (peg top-quest (port->string port)));
+  (peg top-quest port));
 
 (struct quest (name command preRequisites) #:transparent);
 


### PR DESCRIPTION
Hello,

This patch supports calling `peg` with an input port. This is useful for reading expressions one at a time from files and streams.

On my test files performance is actually slightly faster (5% or so) - this may be because `string-contains-substring?` can now be replaced with a single `string=?`.